### PR TITLE
Remove root request

### DIFF
--- a/cha.postman_collection.json
+++ b/cha.postman_collection.json
@@ -151,34 +151,6 @@
 				}
 			},
 			"response": []
-		},
-		{
-			"name": "Root",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"id": "3b67eead-8c7d-4b0a-acd4-ca381430ac86",
-						"exec": [
-							"pm.test('Returns correct code', () => {",
-							"    pm.expect(pm.response.code).to.equal(200)",
-							"})"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
 		}
 	],
 	"auth": {


### PR DESCRIPTION
The root request `/` works fine locally because we are not going through an AWS Gateway. But when talking to an AWS environment because we go through the gateway any request to `/` is picked by the gateway as a request to it. This is why the root request test fails.

It's not really adding any value and was added more for demonstration purposes. So the simplest solution is just to remove it.