### PR TITLE
Add command line parser to project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,6 @@ jobs:
           npm run lint
 
       # Run our CI postman test to confirm we haven't made changes to the project that prevent newman from running
-      - name: Run unit tests
+      - name: Run build test
         run: |
-          npm start example
+          npm start -- -e example

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Git is setup to ignore everything bar the example environment file. Even so, dou
 Running the tests involves firing all the requests in the [cha.postman_collection.json](cha.postman_collection.json) combined with the values taken from the selected environment file. For example, if you wanted to test the **development** environment and had created the environment file `dev.postman_environment.json` you would call
 
 ```bash
-npm start dev
+npm start -- -e dev
 ```
 
 The app will automatically look for a `*.postman_environment.json` with the matching prefix.

--- a/index.js
+++ b/index.js
@@ -1,35 +1,28 @@
 'use strict'
 
-const fs = require('fs')
+const { program } = require('commander')
+const ParamHelper = require('./lib/param_helper')
 const newman = require('newman')
 
-const environment = process.argv.slice(2)[0]
+program
+  .name('cha-tests')
+  .requiredOption('-e, --environment <environment>', 'environment to run tests against')
 
-if (!environment) {
-  console.log("You didn't say which environment file to use!")
-  process.exit(1)
-}
-
-const enviromentFile = fs.readdirSync('./environments', { withFileTypes: true })
-  .filter(item => !item.isDirectory())
-  .map(item => item.name)
-  .find(item => item.startsWith(environment))
-
-if (!enviromentFile) {
-  console.log(`Sorry, we can't find a matching '${environment}' environment file.`)
-  process.exit(1)
-}
-
-let collectionFile = 'cha.postman_collection.json'
-if (environment === 'example') {
-  collectionFile = 'ci.postman_collection.json'
-}
-
-newman.run({
-  collection: require(`./${collectionFile}`),
-  environment: require(`./environments/${enviromentFile}`),
-  reporters: 'cli'
-}, function (err) {
-  if (err) { throw err }
-  console.log('Collection run complete!')
+program.on('--help', () => {
+  console.log('')
+  console.log('Examples:')
+  console.log('  $ npm start -- -e dev')
+  console.log('  $ node index.js -e dev')
 })
+
+program.parse()
+
+const args = ParamHelper.params(program)
+
+newman.run(
+  args,
+  function (err) {
+    if (err) { throw err }
+    console.log('Collection run complete!')
+  }
+)

--- a/lib/param_helper.js
+++ b/lib/param_helper.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const fs = require('fs')
+
+const params = (program) => {
+  return {
+    collection: collectionFile(program.environment),
+    environment: environmentFile(program.environment),
+    reporters: 'cli'
+  }
+}
+
+const collectionFile = (environment) => {
+  let collectionFile = 'cha.postman_collection.json'
+  if (environment === 'example') {
+    collectionFile = 'ci.postman_collection.json'
+  }
+
+  return require(`../${collectionFile}`)
+}
+
+const environmentFile = (environment) => {
+  const file = fs.readdirSync('./environments', { withFileTypes: true })
+    .filter(item => !item.isDirectory())
+    .map(item => item.name)
+    .find(item => item.startsWith(environment))
+
+  if (!file) {
+    console.log(`Sorry, we can't find a matching 'environments/${environment}.postman_environment.json'`)
+    process.exit(1)
+  }
+
+  return require(`../environments/${file}`)
+}
+
+module.exports = { params }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,16 @@
     "type": "git",
     "url": "https://github.com/DEFRA/sroc-cha-acceptance-tests"
   },
+  "bin": {
+    "cha-tests": "./index.js"
+  },
   "scripts": {
     "start": "node index.js",
     "test": "node index.js",
     "lint": "standard"
   },
   "dependencies": {
+    "commander": "^6.2.0",
     "newman": "^5.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
We now know we need to make the arguments to the project more flexible. This is because

- we would like to control which reports we ask [newman](https://github.com/postmanlabs/newman#reporters) to use for output
- we would like to control which tests are run by specifying folders

So in preparation for this we are adding [Commander.js](https://github.com/tj/commander.js) to the project