### PR TITLE
Add support for reporters CLI option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ node_modules/
 environments/*
 !environments/example.postman_environment.json
 
+# Newman output folder
+# If we ask newman to use a reporter other than CLI it will output the result to
+# here. We don't want this output commited as part of source control.
+newman/
+
 # Dotenv https://github.com/motdotla/dotenv
 # Ignore the .env file as this may contain actual credentials. The .env.example
 # file gets committed which acts as documentation on what environment

--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ npm start -- -e dev
 
 The app will automatically look for a `*.postman_environment.json` with the matching prefix.
 
+### Reporters
+
+**Newman** comes with some [built-in reporters](https://github.com/postmanlabs/newman#reporters) the default being the [CLI reporter](https://github.com/postmanlabs/newman#cli-reporter).
+
+When you run the tests you can specify which of these reporters to use
+
+```bash
+npm start -- -e dev -r json
+```
+
+You can even specify multiple reporters
+
+```bash
+npm start -- -e dev -r cli json
+```
+
+If you don't set a reporter the tests will use `cli` as the default.
+
 ### CI
 
 To check we haven't broken anything we have a [separate Postman collection](/ci.postman_collection.json) we use just when running our CI checks. If you call `npm start example` it will run the CI request and test rather than the main charging module ones.

--- a/index.js
+++ b/index.js
@@ -7,12 +7,13 @@ const newman = require('newman')
 program
   .name('cha-tests')
   .requiredOption('-e, --environment <environment>', 'environment to run tests against')
+  .option('-r, --reporters [reporters...]', 'reporters you wish newman to use', 'cli')
 
 program.on('--help', () => {
   console.log('')
   console.log('Examples:')
   console.log('  $ npm start -- -e dev')
-  console.log('  $ node index.js -e dev')
+  console.log('  $ npm start -- -e dev -r cli,json')
 })
 
 program.parse()

--- a/lib/param_helper.js
+++ b/lib/param_helper.js
@@ -6,7 +6,7 @@ const params = (program) => {
   return {
     collection: collectionFile(program.environment),
     environment: environmentFile(program.environment),
-    reporters: 'cli'
+    reporters: program.reporters
   }
 }
 


### PR DESCRIPTION
Now we have a proper command line option parser we can add support for allowing users to specify which reportes to use.

This change updates the project to

- add the command line option
- handle parsing the values provided and passing them to newman