### PR TITLE
Add support for specifying folders on CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ npm start -- -e dev
 
 The app will automatically look for a `*.postman_environment.json` with the matching prefix.
 
+### Folders
+
+The primary means of grouping requests into a 'test' in Postman is using folders in your collection. We can tell **Newman** to only run the requests in a folder through the command line.
+
+```bash
+npm start -- -e dev -f bill-run-test
+```
+
+You can even specify multiple folders
+
+```bash
+npm start -- -e dev -f bill-run-test endpoints-check
+```
+
+If you have setup your collection so each folder represents a 'test', using the `-f` folders option allows you to select which 'tests' to run.
+
+#### Naming folders
+
+In the Postman app it makes perfect sense to name folders with spaces and capitals, for example, **Bill run test**. It looks more readable in the UI! But as the intention is to make them available on the command line to **Newman**, spaces and mixed cases in names can prove problematic.
+
+If you can, stick to all lowercase and go with either [snake_case](https://en.wikipedia.org/wiki/Snake_case) or [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Special_case_styles) rather than using spaces.
+
 ### Reporters
 
 **Newman** comes with some [built-in reporters](https://github.com/postmanlabs/newman#reporters) the default being the [CLI reporter](https://github.com/postmanlabs/newman#cli-reporter).

--- a/index.js
+++ b/index.js
@@ -8,12 +8,14 @@ program
   .name('cha-tests')
   .requiredOption('-e, --environment <environment>', 'environment to run tests against')
   .option('-r, --reporters [reporters...]', 'reporters you wish newman to use', 'cli')
+  .option('-f, --folders [folders...]', 'names of folders in the collection you wish newman to run')
 
 program.on('--help', () => {
   console.log('')
   console.log('Examples:')
   console.log('  $ npm start -- -e dev')
   console.log('  $ npm start -- -e dev -r cli,json')
+  console.log('  $ npm start -- -e dev -r cli -f admin')
 })
 
 program.parse()

--- a/lib/param_helper.js
+++ b/lib/param_helper.js
@@ -17,10 +17,14 @@ const fs = require('fs')
  * @param {Object} program An instance of `require('commander').program` which has parsed `process.argv`
  */
 const params = (program) => {
+  const reporters = optionsToArray(program.reporters)
+  const folders = optionsToArray(program.folders)
+
   return {
     collection: collectionFile(program.environment),
     environment: environmentFile(program.environment),
-    reporters: parseReporters(program.reporters),
+    folder: folders,
+    reporters: parseReporters(reporters),
     // It does not matter if the user does not specify the html reporter. Newman will simply ignore the htmlextra
     // section. But we must specify the `reporter:` property else the htmlextra reporter package fails
     reporter: {
@@ -102,6 +106,35 @@ const parseReporters = (reporters) => {
   }
 
   return unique
+}
+
+/**
+ * Converts a value into an array if it's not already an array
+ *
+ * When using the command line there are scenarios where we could get an array or just a single value. For example, if
+ * you don't specify any reporters using the -r option then Commander.js just returns `'cli'` rather than `['cli']`.
+ * If you were to set `-r cli` on the command line then we would get an array.
+ *
+ * We cater for these scenarios by passing in whatever the options are we are expecting to be an array and if they are
+ * not, we return it in one.
+ *
+ * @param {(string|string[])} options Either an array of options specified on the command line, or a single string value
+ *
+ * @returns {string[]} Either the original `options` if it was already an array, `options` as an array, or an empty
+ * array if `options` was undefined
+ */
+const optionsToArray = (options) => {
+  // If options is null or undefined just return an empty array
+  if (!options) {
+    return []
+  }
+
+  // If the -r option is not specified at the CLI reporters is not an array
+  if (!Array.isArray(options)) {
+    return [options]
+  }
+
+  return options
 }
 
 module.exports = { params }

--- a/lib/param_helper.js
+++ b/lib/param_helper.js
@@ -15,6 +15,7 @@ const fs = require('fs')
  * to use for the test run.
  *
  * @param {Object} program An instance of `require('commander').program` which has parsed `process.argv`
+ * @return {Object} an object that represents the options that need to be passed to `newman.run()`
  */
 const params = (program) => {
   const reporters = optionsToArray(program.reporters)
@@ -23,6 +24,8 @@ const params = (program) => {
   return {
     collection: collectionFile(program.environment),
     environment: environmentFile(program.environment),
+    // If no folders are specified we'll pass in an empty array to Newman. It's clever enough to ignore this and just
+    // run all requests in the collection
     folder: folders,
     reporters: parseReporters(reporters),
     // It does not matter if the user does not specify the html reporter. Newman will simply ignore the htmlextra
@@ -43,7 +46,8 @@ const params = (program) => {
  * If the environment is `example` the it is assumed we are running in CI and just testing that the project builds and
  * runs. Else we return our main `cha.postman_collection.json` collection.
  *
- * @param {String} environment Name of the environment we are running against
+ * @param {string} environment Name of the environment we are running against
+ * @returns {string} the contents of 'cha.postman_collection.json'
  */
 const collectionFile = (environment) => {
   let collectionFile = 'cha.postman_collection.json'
@@ -61,7 +65,8 @@ const collectionFile = (environment) => {
  * a file which has a filename with a matching prefix. For example, if the environment specified is `dev` then this
  * function expects to find `environments/dev.postman_environment.json` and return it.
  *
- * @param {String} environment Name of the environment we are running against
+ * @param {string} environment Name of the environment we are running against
+ * @returns {string} the contents of the matching '[environment].postman_environment.json' file
  */
 const environmentFile = (environment) => {
   const file = fs.readdirSync('./environments', { withFileTypes: true })
@@ -89,7 +94,9 @@ const environmentFile = (environment) => {
  *
  * In addition to this the parser ensures all values are lowercase and removes any accidental duplicates.
  *
- * @param {String[]} reporters Array of strings
+ * @param {string[]} reporters Array of strings
+ * @returns {string[]} an array of string values representing reporters newman should use to generate test output and
+ * results
  */
 const parseReporters = (reporters) => {
   // If the -r option is not specified at the CLI reporters is not an array


### PR DESCRIPTION
You have to specify a collection when using Postman and Newman. However, if your collection contains a folder of requests, you can tell Newman to just one that one folder. You can also pass it an array of folders.

Using folders is really the only means we have to group requests into a 'test'. So by adding support to specify folders in our CLI options, we are effectively adding support for declaring which test(s) you wish to run.