### PR TITLE
Add transaction performance test

### DIFF
--- a/cha.postman_collection.json
+++ b/cha.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "2171aefe-460d-4003-8633-e710de635387",
+		"_postman_id": "d527f10e-afc5-4eaf-9e15-32cf91c2a613",
 		"name": "CHA acceptance tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -14,7 +14,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b7a8386a-292f-40e6-b126-c811b9085985",
 								"exec": [
 									"pm.test('Returns correct code', () => {",
 									"    pm.expect(pm.response.code).to.equal(200)",
@@ -47,7 +46,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "05c3861b-fa91-45ba-8efb-282076b68438",
 								"exec": [
 									"pm.test('Returns correct code', () => {",
 									"    pm.expect(pm.response.code).to.equal(200)",
@@ -101,7 +99,6 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "d8cca2f6-3d01-4be3-a8a1-47cbf1cdee63",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -111,15 +108,295 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "2efabc28-72a5-4a52-ba84-5db6d17d6e3f",
 						"type": "text/javascript",
 						"exec": [
 							""
 						]
 					}
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
+		},
+		{
+			"name": "transaction-performance",
+			"item": [
+				{
+					"name": "01-create-bill-run",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Returns correct code', () => {",
+									"    pm.expect(pm.response.code).to.equal(201)",
+									"})",
+									"",
+									"if (pm.response.code === 201) {",
+									"    pm.environment.set('billRunId', pm.response.json().billRun.id)",
+									"",
+									"    const customers = [\"TH000000001\", \"TH000000002\"]",
+									"    const financialYears = [",
+									"        { periodStart: \"01-APR-2017\", periodEnd: \"31-MAR-2018\" },",
+									"        { periodStart: \"01-APR-2018\", periodEnd: \"31-MAR-2019\" }",
+									"    ]",
+									"    const licences = [",
+									"        \"SROC/TF9222/01\",",
+									"        \"SROC/TF9222/02\",",
+									"        \"SROC/TF9222/03\",",
+									"        \"SROC/TF9222/04\",",
+									"        \"SROC/TF9222/05\"",
+									"    ]",
+									"",
+									"    // We have 2 customers each with 2 financial years and 5 distinct licences. This results",
+									"    // in 10 distinct requests. We repeat each 5 times which results in 100 transactions. We",
+									"    // create an array containing an object for each transaction request. We'll then iterate",
+									"    // through this in the pre-request script of 02-add-bill-run-transaction",
+									"    const transactions = []",
+									"    for (var customer of customers) {",
+									"        for (var year of financialYears) {",
+									"            for (var licence of licences) {",
+									"                for (let i = 0; i < 5; i++) {",
+									"                    // Use the mod operator to divide i by 2. If there is a remainder we set",
+									"                    // credit to false. If no remainder we set it to true. This means for",
+									"                    // every 5 transaction 3 will be debits and 2 credits",
+									"                    const credit = (i % 2) === 0 ? true : false",
+									"                    const transaction = {",
+									"                        customerReference: customer,",
+									"                        periodStart: year.periodStart,",
+									"                        periodEnd: year.periodEnd,",
+									"                        chargePeriod: `${year.periodStart} - ${year.periodEnd}`,",
+									"                        licenceNumber: licence,",
+									"                        credit: credit",
+									"                    }",
+									"                    transactions.push(transaction)",
+									"                }",
+									"            }",
+									"        }",
+									"    }",
+									"",
+									"    pm.variables.set(\"billRunTransactions\", JSON.stringify(transactions))",
+									"    // transactionIndex will be used to track the 100 requests we are sending to to the",
+									"    // create bill run transaction endpoint",
+									"    pm.variables.set(\"transactionIndex\", 0)",
+									"}",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"region\": \"A\"\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/v1/{{slug}}/billruns",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"v1",
+								"{{slug}}",
+								"billruns"
+							]
+						},
+						"description": "This endpoint triggers creation of a bill run record for a region. Bill run contains no transactions on creation."
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"description": {
+											"content": "Added as a part of security scheme: oauth2",
+											"type": "text/plain"
+										},
+										"key": "Authorization",
+										"value": "<token>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"region\": \"A\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/v1/:regime/billruns",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										":regime",
+										"billruns"
+									],
+									"variable": [
+										{
+											"key": "regime"
+										}
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n \"billRun\": {\n  \"id\": \"2bbbe459-966e-4026-b5d2-2f10867bdddd\",\n  \"billRunNumber\": 10004\n }\n}"
+						}
+					]
+				},
+				{
+					"name": "02-add-bill-run-transaction",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Fetch the test transactions generated in 01-create-bill-run and the current transaction",
+									"// index and pull the transaction data out of the list",
+									"",
+									"const billRunTransactions = JSON.parse(pm.variables.get('billRunTransactions'))",
+									"let transactionIndex = parseInt(pm.variables.get('transactionIndex'))",
+									"const transaction = billRunTransactions[transactionIndex]",
+									"",
+									"// Then set our variables ready for inclusion in the request we are about to send but only ",
+									"if (transaction) {",
+									"    pm.variables.set('customerReference', transaction.customerReference)",
+									"    pm.variables.set('periodStart', transaction.periodStart)",
+									"    pm.variables.set('periodEnd', transaction.periodEnd)",
+									"    pm.variables.set('chargePeriod', transaction.chargePeriod)",
+									"    pm.variables.set('licenceNumber', transaction.licenceNumber)",
+									"    pm.variables.set('credit', transaction.credit)",
+									"",
+									"    postman.setNextRequest(\"02-add-bill-run-transaction\")",
+									"}",
+									"",
+									"// Increment our index and save it",
+									"transactionIndex = transactionIndex + 1",
+									"pm.variables.set('transactionIndex', transactionIndex)",
+									"",
+									"console.log(`Sending request number ${transactionIndex} of ${billRunTransactions.length}`)",
+									"",
+									"// Without this bit of code we get 101 transaction requests. It's related to confusion of",
+									"// the request being a 'thing' in the postman collection, but us using it to programmatically",
+									"// create additional ones.",
+									"if (transactionIndex >= billRunTransactions.length) {",
+									"    postman.setNextRequest(null)",
+									"}",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Returns correct code', () => {",
+									"    pm.expect(pm.response.code).to.equal(201)",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"periodStart\": \"{{periodStart}}\",\n    \"periodEnd\": \"{{periodEnd}}\",\n    \"credit\": {{credit}},\n    \"billableDays\": 310,\n    \"authorisedDays\": 365,\n    \"volume\": \"6.22\",\n    \"source\": \"Supported\",\n    \"season\": \"Summer\",\n    \"loss\": \"Low\",\n    \"twoPartTariff\": false,\n    \"compensationCharge\": false,\n    \"eiucSource\": \"Tidal\",\n    \"waterUndertaker\": false,\n    \"regionalChargingArea\": \"Anglian\",\n    \"section127Agreement\": false,\n    \"section130Agreement\": false,\n    \"customerReference\": \"{{customerReference}}\",\n    \"lineDescription\": \"Well at Chigley Town Hall\",\n    \"licenceNumber\": \"{{licenceNumber}}\",\n    \"chargePeriod\": \"{{chargePeriod}}\",\n    \"chargeElementId\": \"\",\n    \"batchNumber\": \"TONY10\",\n    \"region\": \"A\",\n    \"areaCode\": \"ARCA\",\n    \"newLicence\": false\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/v1/{{slug}}/billruns/{{billRunId}}/transactions",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"v1",
+								"{{slug}}",
+								"billruns",
+								"{{billRunId}}",
+								"transactions"
+							]
+						},
+						"description": "Triggers creation of a transaction and immediately adds it to the specified bill run."
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"description": {
+											"content": "Added as a part of security scheme: oauth2",
+											"type": "text/plain"
+										},
+										"key": "Authorization",
+										"value": "<token>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"periodStart\": \"01-APR-2019\",\n    \"periodEnd\": \"31-MAR-2020\",\n    \"credit\": false,\n    \"billableDays\": 310,\n    \"authorisedDays\": 365,\n    \"volume\": \"6.22\",\n    \"source\": \"Supported\",\n    \"season\": \"Summer\",\n    \"loss\": \"Low\",\n    \"twoPartTariff\": false,\n    \"compensationCharge\": false,\n    \"eiucSource\": \"Tidal\",\n    \"waterUndertaker\": false,\n    \"regionalChargingArea\": \"Anglian\",\n    \"section127Agreement\": false,\n    \"section130Agreement\": false,\n    \"customerReference\": \"TH230000222\",\n    \"lineDescription\": \"Well at Chigley Town Hall\",\n    \"licenceNumber\": \"TONY/TF9222/37\",\n    \"chargePeriod\": \"01-APR-2018 - 31-MAR-2019\",\n    \"chargeElementId\": \"\",\n    \"batchNumber\": \"TONY10\",\n    \"region\": \"W\",\n    \"areaCode\": \"ARCA\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/v1/:regime/billruns/:billrunId/transactions",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"v1",
+										":regime",
+										"billruns",
+										":billrunId",
+										"transactions"
+									],
+									"variable": [
+										{
+											"key": "regime"
+										},
+										{
+											"key": "billrunId"
+										}
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n \"transaction\": {\n  \"id\": \"fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3\"\n }\n}"
+						}
+					]
+				}
+			]
 		},
 		{
 			"name": "Status",
@@ -127,7 +404,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "fafbf491-dca9-437e-947d-f72bf3be90dd",
 						"exec": [
 							"pm.test(\"Returns correct code\", () => {",
 							"    pm.expect(pm.response.code).to.equal(200)",
@@ -167,7 +443,6 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "780d1f37-4099-4ce3-87bf-34127fd610ab",
 				"type": "text/javascript",
 				"exec": [
 					"// Use to automate refreshing the AWS cognito bearer token in Postman",
@@ -331,7 +606,6 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "5cd7a31e-b6df-4f45-b9d8-45d00e42a308",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -341,10 +615,8 @@
 	],
 	"variable": [
 		{
-			"id": "8d1e9436-519e-4a9d-8029-d26c562651f2",
 			"key": "slug",
 			"value": "wrls"
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }


### PR DESCRIPTION
https://trello.com/c/gTcQmR8M

This adds a test (folder) to the Postman collection which creates a new bill run and then adds 100 transactions to it. The test includes logic that ensures we have a mix of customers, financial years and licence numbers. It has been created to give an early indicator of how changes to how a transaction is created impacts average response times.

![cha_test_v4_01](https://user-images.githubusercontent.com/1789650/103420463-3a923900-4b8f-11eb-90a7-3b82e3270dec.png)
