### PR TITLE
Fix admin regime request tests

### DIFF
--- a/cha.postman_collection.json
+++ b/cha.postman_collection.json
@@ -9,7 +9,7 @@
 			"name": "admin",
 			"item": [
 				{
-					"name": "List Regimes",
+					"name": "1. List regimes",
 					"event": [
 						{
 							"listen": "test",
@@ -18,6 +18,16 @@
 									"pm.test('Returns correct code', () => {",
 									"    pm.expect(pm.response.code).to.equal(200)",
 									"})",
+									"",
+									"// Get and store wrls regime Id for next request",
+									"const response = pm.response.json();",
+									"const result = response.filter(obj => {",
+									"  return obj.slug === 'wrls'",
+									"})[0]",
+									"",
+									"if (result) {",
+									"  pm.environment.set(\"regimeId\", result.id);",
+									"}",
 									""
 								],
 								"type": "text/javascript"
@@ -41,7 +51,7 @@
 					"response": []
 				},
 				{
-					"name": "Show regimes",
+					"name": "2. Show \"wrls\" regime",
 					"event": [
 						{
 							"listen": "test",
@@ -77,7 +87,7 @@
 							"variable": [
 								{
 									"key": "id",
-									"value": "{{slug}}",
+									"value": "{{regimeId}}",
 									"type": "string"
 								}
 							]

--- a/cha.postman_collection.json
+++ b/cha.postman_collection.json
@@ -63,7 +63,7 @@
 									"pm.test('Returns the expected regime', () => {",
 									"    const body = pm.response.json()",
 									"",
-									"    pm.expect(body.regime.slug).to.equal(pm.variables.get('slug'))",
+									"    pm.expect(body.slug).to.equal('wrls')",
 									"})",
 									""
 								],


### PR DESCRIPTION
If you try and run the requests in the admin folder you get an error. This is because the `Show regimes` request still assumes we are using the v1 format of regime 'slug'.

This fixes the requests so we can get closer to a point where you can run everything in the collection and not have to stipulate specific folders.