### PR TITLE
Update section126Factor decimal places error check

### DIFF
--- a/cha.postman_collection.json
+++ b/cha.postman_collection.json
@@ -4402,7 +4402,7 @@
 									"});",
 									"",
 									"pm.test(\"Verify error message for indication of section126Factor data input must be a number with up to 3 decimal places\", function () {",
-									"    pm.expect(response.message).to.include(\"\\\"section126Factor\\\" must be a number with no more than 3 decimal places\");",
+									"    pm.expect(response.message).to.include(\"\\\"section126Factor\\\" must have no more than 3 decimal places\");",
 									"});",
 									"",
 									""
@@ -7025,7 +7025,7 @@
 									"});",
 									"",
 									"pm.test(\"Verify error message for indication of section126Factor data input must be a number with up to 3 decimal places\", function () {",
-									"    pm.expect(response.message).to.include(\"\\\"section126Factor\\\" must be a number with no more than 3 decimal places\");",
+									"    pm.expect(response.message).to.include(\"\\\"section126Factor\\\" must have no more than 3 decimal places\");",
 									"});"
 								],
 								"type": "text/javascript"


### PR DESCRIPTION
Both `calculate-pre-sroc-charge-in-transaction` and `calculate-standalone-pre-sroc-charge` have checks that ensure the `section126Factor` of a charge request does not allow more than 3 decimal places. The transaction file the value gets exported to has this limit and we do not want to take responsibility for rounding values sent by client systems.

So, we must reject `section126Factor` values which have more than 3 decimal places. We have just [fixed the API](https://github.com/DEFRA/sroc-charging-module-api/pull/191) to ensure this is the case. The only thing we need to change in the tests is the check for the error message (it's not quite the same).