### PR TITLE
Updating waterUndertaker tests to verify conditional validation

### DIFF
--- a/cha.postman_collection.json
+++ b/cha.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "1f4b2569-4305-4dc1-9655-f317133e129b",
+		"_postman_id": "1fe029e2-b0d1-4bd9-9342-3499826ab768",
 		"name": "CHA acceptance tests v2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -87,8 +87,7 @@
 							"variable": [
 								{
 									"key": "id",
-									"value": "{{regimeId}}",
-									"type": "string"
+									"value": "{{regimeId}}"
 								}
 							]
 						}
@@ -1740,7 +1739,7 @@
 					"response": []
 				},
 				{
-					"name": "17. \"waterUndertaker\" is mandatory and Transaction is not created",
+					"name": "17. \"waterUndertaker\" is mandatory when \"compensationCharge\" is true and Transaction is not created",
 					"event": [
 						{
 							"listen": "test",
@@ -1773,7 +1772,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"periodStart\": \"01-APR-2020\",\r\n    \"periodEnd\": \"31-MAR-2021\",\r\n    \"credit\": false,\r\n    \"billableDays\": 310,\r\n    \"authorisedDays\": 365,\r\n    \"volume\": \"110\",\r\n    \"source\": \"Tidal\",\r\n    \"season\": \"Summer\",\r\n    \"loss\": \"Low\",\r\n    \"twoPartTariff\": false,\r\n    \"compensationCharge\": false,\r\n    \"regionalChargingArea\": \"Thames\",\r\n    \"section127Agreement\": true,\r\n    \"section130Agreement\": false,\r\n    \"customerReference\": \"T1234567890A\",\r\n    \"lineDescription\": \"Drains within Littleport & Downham IDB\",\r\n    \"licenceNumber\": \"ExtraRgnY_record1\",\r\n    \"chargePeriod\": \"01-APR-2020 - 31-MAR-2021\",\r\n    \"region\": \"T\",\r\n    \"areaCode\": \"ARCA\"\r\n}"
+							"raw": "{\r\n    \"periodStart\": \"01-APR-2020\",\r\n    \"periodEnd\": \"31-MAR-2021\",\r\n    \"credit\": false,\r\n    \"billableDays\": 310,\r\n    \"authorisedDays\": 365,\r\n    \"volume\": \"110\",\r\n    \"source\": \"Tidal\",\r\n    \"season\": \"Summer\",\r\n    \"loss\": \"Low\",\r\n    \"twoPartTariff\": false,\r\n    \"compensationCharge\": true,\r\n    \"eiucSource\": \"Unsupported\",\r\n    \"regionalChargingArea\": \"Thames\",\r\n    \"section127Agreement\": true,\r\n    \"section130Agreement\": false,\r\n    \"customerReference\": \"T1234567890A\",\r\n    \"lineDescription\": \"Drains within Littleport & Downham IDB\",\r\n    \"licenceNumber\": \"ExtraRgnY_record1\",\r\n    \"chargePeriod\": \"01-APR-2020 - 31-MAR-2021\",\r\n    \"region\": \"T\",\r\n    \"areaCode\": \"ARCA\"\r\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/v2/wrls/bill-runs/{{billRun_id}}/transactions",
@@ -2586,6 +2585,59 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\r\n    \"periodStart\": \"01-APR-2020\",\r\n    \"periodEnd\": \"31-MAR-2021\",\r\n    \"credit\": false,\r\n\t\"billableDays\": 310,\r\n\t\"authorisedDays\": 365,\r\n    \"volume\": \"110\",\r\n    \"source\": \"Tidal\",\r\n    \"season\": \"Summer\",\r\n    \"loss\": \"Low\",\r\n    \"twoPartTariff\": false,\r\n    \"compensationCharge\": false,\r\n    \"waterUndertaker\": false,\r\n    \"regionalChargingArea\": \"Thames\",\r\n\t\"section127Agreement\": true,\r\n\t\"section130Agreement\": false,\r\n    \"customerReference\": \"T1234567890A\",\r\n    \"lineDescription\": \"Drains within Littleport & Downham IDB\",\r\n    \"licenceNumber\": \"ExtraRgnY_record1\",\r\n    \"chargePeriod\": \"01-APR-2020 - 31-MAR-2021\",\r\n    \"region\": \"T\",\r\n    \"areaCode\": \"ARCA\",\r\n    \"subjectToMinimumCharge\": \"Test\"\r\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/v2/wrls/bill-runs/{{billRun_id}}/transactions",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"v2",
+								"wrls",
+								"bill-runs",
+								"{{billRun_id}}",
+								"transactions"
+							]
+						},
+						"description": "add transaction to queue"
+					},
+					"response": []
+				},
+				{
+					"name": "33. \"eiuCSource\" is mandatory when \"compensationCharge\" is true and Transaction is not created",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const response = pm.response.json();",
+									"console.log(\"Creating a Transaction and adding to Bill run\");",
+									"",
+									"pm.test(\"Status code is 422 Unprocessable\", function () {",
+									"    pm.response.to.have.status(422);",
+									"});",
+									"",
+									"pm.test(\"Verify input eiucSource is required\", function () {",
+									"    pm.expect(response.message).to.include(\"\\\"eiucSource\\\" is required\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"periodStart\": \"01-APR-2020\",\r\n    \"periodEnd\": \"31-MAR-2021\",\r\n    \"credit\": false,\r\n    \"billableDays\": 310,\r\n    \"authorisedDays\": 365,\r\n    \"volume\": \"110\",\r\n    \"source\": \"Tidal\",\r\n    \"season\": \"Summer\",\r\n    \"loss\": \"Low\",\r\n    \"twoPartTariff\": false,\r\n    \"compensationCharge\": true,\r\n    \"waterUndertaker\": false,\r\n    \"regionalChargingArea\": \"Thames\",\r\n    \"section127Agreement\": true,\r\n    \"section130Agreement\": false,\r\n    \"customerReference\": \"T1234567890A\",\r\n    \"lineDescription\": \"Drains within Littleport & Downham IDB\",\r\n    \"licenceNumber\": \"ExtraRgnY_record1\",\r\n    \"chargePeriod\": \"01-APR-2020 - 31-MAR-2021\",\r\n    \"region\": \"T\",\r\n    \"areaCode\": \"ARCA\"\r\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/v2/wrls/bill-runs/{{billRun_id}}/transactions",


### PR DESCRIPTION
It is confirmed that `waterUndertaker` is only a mandatory item when `compensationCharge` is set to `true`. Previous tests incorrectly checked for `waterUndertaker` to be mandatory in all circumstances. This updates the following:

- The test now verifies that `waterUndertaker` is only mandatory when `compensationCharge` is set to 'true'
- A new test has been added to cover `eiucSource` under the same rule. 